### PR TITLE
Adding notes about newest LTS version, and the fixes needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
 
     dudo apt-get update
 
-    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm repo
+    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm repo pkg-config
 
     Rust toolchain & programs are also required. We recommend you to install them using rustup !
     First, remove distro' Rust toolchain:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
 ## Grabbing Dependencies
     sudo nano /etc/apt/sources.list.d/ubuntu.sources
     Verify you have focal-security in your sources if you are on any version above Focal Fossa (20.04 LTS). Latest LTS is currently Ubuntu 24.04.2 LTS as of 04/22/2025.
-    ![image](https://github.com/user-attachments/assets/d9a3e6d7-6db4-49fc-8274-b8a3945edbd5)
+![image](https://github.com/user-attachments/assets/d9a3e6d7-6db4-49fc-8274-b8a3945edbd5)
 
     sudo dpkg --add-architecture i386
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
     For Linux they recomend running the shell script below to begin the install
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
+    
+    Rust is installed now. Great!
+
+    To get started you may need to restart your current shell.
+    This would reload your PATH environment variable to include
+    Cargo's bin directory ($HOME/.cargo/bin).
+
+    To configure your current shell, you need to source
+    the corresponding env file under $HOME/.cargo.
+
+    This is usually done by running one of the following (note the leading DOT):
+    . "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
+    source "$HOME/.cargo/env.fish"  # For fish
+    source "$HOME/.cargo/env.nu"    # For nushell
+
+
     After getting rustup installed, install required programs & toolchain:
     cargo install cargo-ndk
     rustup target add x86_64-linux-android i686-linux-android

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
 
     dudo apt-get update
 
-    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm repo pkg-config
+    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm repo pkg-config python3 python3-pip python3-ply
 
     Rust toolchain & programs are also required. We recommend you to install them using rustup !
     First, remove distro' Rust toolchain:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
 
     dudo apt-get update
 
-    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm
+    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm repo
 
     Rust toolchain & programs are also required. We recommend you to install them using rustup !
     First, remove distro' Rust toolchain:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,15 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
 -----------------------
 
 ## Grabbing Dependencies
+    sudo nano /etc/apt/sources.list.d/ubuntu.sources
+    Verify you have focal-security in your sources if you are on any version above Focal Fossa (20.04 LTS). Latest LTS is currently Ubuntu 24.04.2 LTS as of 04/22/2025.
+    ![image](https://github.com/user-attachments/assets/d9a3e6d7-6db4-49fc-8274-b8a3945edbd5)
 
-    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm
+    sudo dpkg --add-architecture i386
+
+    dudo apt-get update
+
+    sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386  lib32ncurses-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip squashfs-tools python3-mako libssl-dev ninja-build lunzip syslinux syslinux-utils gettext genisoimage gettext bc xorriso xmlstarlet meson glslang-tools git-lfs libncurses5 libncurses5:i386 libelf-dev aapt zstd rdfind nasm
 
     Rust toolchain & programs are also required. We recommend you to install them using rustup !
     First, remove distro' Rust toolchain:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
     
     Next install rustup by following this page:
     https://www.rust-lang.org/tools/install
+    For Linux they recomend running the shell script below to begin the install
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
     After getting rustup installed, install required programs & toolchain:
     cargo install cargo-ndk

--- a/android-x86/04-custom.xml
+++ b/android-x86/04-custom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <!-- Initrd & installer -->
-  <project path="bootable/newinstaller" name="bootable_newinstaller" remote="BlissOS" revision="typhoon-x86" />
+  <project path="bootable/aaropa" name="bootable_aaropa" remote="BlissOS" revision="typhoon-x86" />
 
   <!-- Device tree -->
   <project path="device/generic/common" name="device_generic_common" remote="BlissOS" sync-s="true" />


### PR DESCRIPTION
this PR fixes the readme for all Bliss os install instructions for newest LTS