### PR TITLE
Update hard drive space requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please read the [AOSP building instructions](http://source.android.com/source/in
     Latest Ubuntu LTS Releases https://www.ubuntu.com/download/server
     Decent CPU (Dual Core or better for a faster performance)
     24GB RAM (30GB for Virtual Machine)
-    250GB Hard Drive (about 170GB for the Repo and then building space needed)
+    350GB Hard Drive (about 180GB for the Repo and then building space needed)
   
 -----------------------
 


### PR DESCRIPTION
more diskspace needed, increasing the requirements to 350GB
blissbuild$ du -d 1 -h
```
2.1G    ./cts
718M    ./system
35M     ./toolchain
111M    ./libcore
3.1G    ./vendor
896K    ./pdk
64M     ./bionic
291M    ./bootable
109G    ./out
62M     ./build
2.6G    ./packages
100K    ./bliss
61G     ./prebuilts
3.8G    ./device
148K    ./glodroid
12M     ./sdk
6.0G    ./kernel
99G     ./.repo
180M    ./platform_testing
109M    ./art
937M    ./hardware
358M    ./test
16M     ./trusty
772K    ./manifest
1.1G    ./tools
2.0G    ./frameworks
19G     ./external
440M    ./developers
644K    ./libnativehelper
410M    ./development
26M     ./dalvik
311G    .
```
